### PR TITLE
Fixing bug with non profileset sims

### DIFF
--- a/simParser.py
+++ b/simParser.py
@@ -33,7 +33,7 @@ def parse(filename, isCsv, hideHeaders, hideProfiles, hideActors, dpsOnly):
                     ret+= '{0:.{1}f}'.format(weights['Mastery'],2) + separator
                     ret+= '{0:.{1}f}'.format(weights['Vers'],2)
                 ret+= '\n'
-    if sim['sim']['profilesets']:
+    if 'profilesets' in sim['sim']:
         ret+= parseProfileSets(filename, isCsv, hideHeaders, hideProfiles, hideActors, dpsOnly)
     return ret+ '\n' if not hideHeaders else ret
     


### PR DESCRIPTION
With a normal non-profileset sim running the script produces:
```
Traceback (most recent call last):
  File "simParser.py", line 103, in <module>
    main()
  File "simParser.py", line 97, in main
    parses += parse(filename, options.csv, options.hideHeaders, options.hideProfiles, options.hideActors, options.dpsOnly)
  File "simParser.py", line 36, in parse
    if sim['sim']['profilesets']:
KeyError: 'profilesets'
```

Changing this line fixes that